### PR TITLE
Refactor React Query usage and tighten types

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,11 @@
-import React from "react";
 import { Routes, Route } from "react-router-dom";
 import Layout from "./components/Layout";
-// Update the import path to match the actual file name, e.g. Login.tsx or login.tsx
 import Login from "./pages/Login";
-// Update the import path to match the actual file name, e.g. Dashboard.tsx or dashboard.tsx
 import Dashboard from "./pages/Dashboard";
 import ProductList from "./pages/products/List";
-import Movements from "./pages/movements/Movements"; // <-- Update this path if the file name or casing is different, e.g. "./pages/movements/movements" or "./pages/movements/Movement"
+import Movements from "./pages/movements/Movements";
 import Reports from "./pages/reports/Reports";
-import Users from "./pages/Users";
+import Users from "./pages/users/Users";
 import RequireAuth from "./auth/RequireAuth";
 import EditForm from "./pages/products/EditForm";
 
@@ -22,7 +19,6 @@ export default function App() {
           <Route path="products" element={<ProductList />} />
           <Route path="movements" element={<Movements />} />
           <Route path="reports" element={<Reports />} />
-          <Route path="products" element={<ProductList />} />
           <Route path="products/new" element={<EditForm />} />
           <Route path="products/edit/:id" element={<EditForm />} />
 

--- a/src/auth/AuthContext.tsx
+++ b/src/auth/AuthContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext, useMemo, useState } from "react";
+import type { ReactNode, FC } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
 import api from "../api/axios";
 
 type AuthCtx = {
@@ -10,9 +11,9 @@ type AuthCtx = {
   hasRole: (role: string) => boolean;
 };
 
-const Ctx = createContext<AuthCtx>(null as any);
+const Ctx = createContext<AuthCtx | null>(null);
 
-export const AuthProvider: React.FC<{children: React.ReactNode}> = ({children}) => {
+export const AuthProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [token, setToken] = useState<string | null>(localStorage.getItem("token"));
   const [username, setUsername] = useState<string | null>(localStorage.getItem("username"));
   const [roles, setRoles] = useState<string[]>(
@@ -38,9 +39,16 @@ export const AuthProvider: React.FC<{children: React.ReactNode}> = ({children}) 
 
   const hasRole = (r: string) => roles.includes(r) || roles.includes(`ROLE_${r}`);
 
-  const value = useMemo(() => ({ token, username, roles, login, logout, hasRole }), [token, username, roles]);
+  const value = useMemo(
+    () => ({ token, username, roles, login, logout, hasRole }),
+    [token, username, roles, login, logout, hasRole]
+  );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>
 };
-
-export const useAuth = () => useContext(Ctx);
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAuth = () => {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error("AuthProvider missing");
+  return ctx;
+};

--- a/src/auth/RequireAuth.tsx
+++ b/src/auth/RequireAuth.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Navigate, Outlet } from "react-router-dom";
 import { useAuth } from "./AuthContext";
 

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,9 +1,9 @@
-import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import api from "../api/axios";
 import { useDownload } from "../hooks/useDownload";
 import { Link } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
+import type { Page } from "../types";
 
 // --- Tipler ---
 type Metrics = {
@@ -25,14 +25,6 @@ type Movement = {
   quantity: number;
   unitPrice?: number;
   user?: string;
-};
-
-type Page<T> = {
-  content: T[];
-  totalElements: number;
-  totalPages: number;
-  size: number;
-  number: number;
 };
 
 // --- API çağrıları ---

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import type { FormEvent } from "react";
+import { useState } from "react";
 import { useAuth } from "../auth/AuthContext";
 import { useNavigate } from "react-router-dom";
 
@@ -9,14 +10,15 @@ export default function Login() {
   const [p, setP] = useState("");
   const [err, setErr] = useState("");
 
-  const submit = async (e: React.FormEvent) => {
+  const submit = async (e: FormEvent) => {
     e.preventDefault();
     setErr("");
     try {
-      await login(u,p);
+      await login(u, p);
       nav("/");
-    } catch (e: any) {
-      setErr(e.message || "Giriş başarısız");
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "Giriş başarısız";
+      setErr(msg);
     }
   };
 

--- a/src/pages/movements/Movements.tsx
+++ b/src/pages/movements/Movements.tsx
@@ -1,7 +1,8 @@
 import React from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import api from "../../api/axios";
 import { useDownload } from "../../hooks/useDownload";
+import type { Page } from "../../types";
 
 type Movement = {
   id: number;
@@ -14,18 +15,15 @@ type Movement = {
   user?: string;
 };
 
-type Page<T> = {
-  content: T[];
-  totalElements: number;
-  totalPages: number;
-  size: number;
-  number: number;
-};
-
 async function fetchMovements(params: {
-  page: number; size: number; sort: string;
-  from?: string; to?: string; warehouseId?: string; q?: string;
-}) {
+  page: number;
+  size: number;
+  sort: string;
+  from?: string;
+  to?: string;
+  warehouseId?: string;
+  q?: string;
+}): Promise<Page<Movement>> {
   const { data } = await api.get<Page<Movement>>("/api/stock-movements", { params });
   return data;
 }
@@ -79,8 +77,17 @@ export default function Movements() {
 
   const query = useQuery<Page<Movement>>({
     queryKey: ["movements", filters],
-    queryFn: () => fetchMovements({ page: filters.page, size: filters.size, sort: filters.sort, from: filters.from, to: filters.to, warehouseId: filters.wh || undefined, q: filters.q || undefined }),
-    keepPreviousData: true
+    queryFn: () =>
+      fetchMovements({
+        page: filters.page,
+        size: filters.size,
+        sort: filters.sort,
+        from: filters.from,
+        to: filters.to,
+        warehouseId: filters.wh || undefined,
+        q: filters.q || undefined,
+      }),
+    placeholderData: keepPreviousData,
   });
 
   const doExport = (fmt: "pdf"|"xlsx") => {

--- a/src/pages/products/List.tsx
+++ b/src/pages/products/List.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import api from "../../api/axios";
+import type { Page } from "../../types";
 
 type Product = {
   id: number;
@@ -11,11 +12,11 @@ type Product = {
   createdAt?: string;
 };
 
-async function fetchProducts(page: number, size: number, q: string, sort: string) {
-  const { data } = await api.get("/api/products", {
+async function fetchProducts(page: number, size: number, q: string, sort: string): Promise<Page<Product>> {
+  const { data } = await api.get<Page<Product>>("/api/products", {
     params: { page, size, sort, q }
   });
-  return data; // Spring Page
+  return data;
 }
 
 export default function ProductList() {
@@ -24,10 +25,10 @@ export default function ProductList() {
   const [q, setQ] = React.useState("");
   const [sort, setSort] = React.useState("id,desc");
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, isError } = useQuery<Page<Product>>({
     queryKey: ["products", page, size, q, sort],
     queryFn: () => fetchProducts(page, size, q, sort),
-    keepPreviousData: true
+    placeholderData: keepPreviousData,
   });
 
   return (

--- a/src/pages/reports/Reports.tsx
+++ b/src/pages/reports/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useDownload } from "../../hooks/useDownload";
 
 export default function Reports() {

--- a/src/pages/users/Users.tsx
+++ b/src/pages/users/Users.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import api from "../../api/axios";
+import type { Page } from "../../types";
 
 type User = {
   id: number;
@@ -9,9 +10,7 @@ type User = {
   enabled?: boolean;
 };
 
-type Page<T> = { content: T[]; totalElements: number; totalPages: number; size: number; number: number; };
-
-async function fetchUsers(params: { page: number; size: number; q?: string }) {
+async function fetchUsers(params: { page: number; size: number; q?: string }): Promise<Page<User>> {
   const { data } = await api.get<Page<User>>("/api/users", { params });
   return data;
 }
@@ -34,7 +33,11 @@ export default function Users() {
   const [size, setSize] = React.useState(10);
   const [q, setQ] = React.useState("");
 
-  const usersQ = useQuery({ queryKey: ["users", page, size, q], queryFn: () => fetchUsers({ page, size, q: q || undefined }), keepPreviousData: true });
+  const usersQ = useQuery<Page<User>>({
+    queryKey: ["users", page, size, q],
+    queryFn: () => fetchUsers({ page, size, q: q || undefined }),
+    placeholderData: keepPreviousData,
+  });
   const rolesQ = useQuery({ queryKey: ["roles"], queryFn: fetchRoles });
 
   const createMut = useMutation({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,7 @@
+export type Page<T> = {
+  content: T[];
+  totalElements?: number;
+  totalPages: number;
+  number: number;
+  size?: number;
+};


### PR DESCRIPTION
## Summary
- add shared `Page` type and use type-only imports
- replace deprecated `keepPreviousData` with `placeholderData`
- clean up auth and form logic for better type safety

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b84ee4088c83208b67a784dcc2e33c